### PR TITLE
Remove constructor parameters from TimeAxisTickRenderer/ResourceAxisTickRenderer

### DIFF
--- a/projects/ngx-d3timeline/src/lib/axis/axis.service.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/axis.service.ts
@@ -7,7 +7,7 @@ import { Line } from './line';
 import { ScalesService } from '../scales.service';
 import { OptionsService } from '../options.service';
 import { TimelineView } from '../view/timeline-view';
-import { BandScale, TimeScale } from '../scale-types';
+import { Scale } from '../scale-types';
 import { ResourceAxisTickRenderer } from './resources-axis/resource-axis-tick-renderer';
 import { TimeAxisTickRenderer } from './time-axis/time-axis-tick-renderer';
 import { TickRenderer } from './tick-renderer';
@@ -17,7 +17,7 @@ export class AxisService {
   resourceAxis$ = this.scalesService.scales$.pipe(
     map(scales =>
       this.createAxis(
-        new ResourceAxisTickRenderer(scales.scaleBand),
+        new ResourceAxisTickRenderer(),
         scales.scaleBand,
         scales.state.axisOrientations.resourceOrientation,
         scales.state.view
@@ -28,7 +28,7 @@ export class AxisService {
   timeAxis$ = this.scalesService.scales$.pipe(
     map(scales =>
       this.createAxis(
-        new TimeAxisTickRenderer(scales.scaleTime),
+        new TimeAxisTickRenderer(),
         scales.scaleTime,
         scales.state.axisOrientations.timeOrientation,
         scales.state.view
@@ -41,35 +41,36 @@ export class AxisService {
     private optionsService: OptionsService
   ) {}
 
-  private createAxis(
-    tickRenderer: TickRenderer,
-    scale: BandScale | TimeScale,
+  private createAxis<TScale extends Scale>(
+    tickRenderer: TickRenderer<TScale>,
+    scale: TScale,
     orientation: Orientation,
     timelineView: TimelineView
   ): Axis {
     return {
-      ticks: this.getTicks(tickRenderer, orientation, timelineView),
+      ticks: this.getTicks(tickRenderer, scale, orientation, timelineView),
       axisLine: this.getAxisLine(scale, orientation, timelineView)
     };
   }
 
-  private getTicks(
-    tickRenderer: TickRenderer,
+  private getTicks<TScale extends Scale>(
+    tickRenderer: TickRenderer<TScale>,
+    scale: TScale,
     orientation: Orientation,
     timelineView: TimelineView
   ): Tick[] {
-    return tickRenderer.getTickValues().map(value => ({
-      label: tickRenderer.getLabel(value),
+    return tickRenderer.getTickValues(scale).map(value => ({
+      label: tickRenderer.getLabel(scale, value),
       transform: this.optionsService.getTranslation(
-        tickRenderer.getTransform(value),
+        tickRenderer.getTransform(scale, value),
         orientation,
         timelineView
       )
     }));
   }
 
-  private getAxisLine(
-    scale: BandScale | TimeScale,
+  private getAxisLine<TScale extends Scale>(
+    scale: TScale,
     orientation: Orientation,
     timelineView: TimelineView
   ): Line {

--- a/projects/ngx-d3timeline/src/lib/axis/axis.service.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/axis.service.ts
@@ -8,13 +8,16 @@ import { ScalesService } from '../scales.service';
 import { OptionsService } from '../options.service';
 import { TimelineView } from '../view/timeline-view';
 import { BandScale, TimeScale } from '../scale-types';
+import { ResourceAxisTickRenderer } from './resources-axis/resource-axis-tick-renderer';
+import { TimeAxisTickRenderer } from './time-axis/time-axis-tick-renderer';
+import { TickRenderer } from './tick-renderer';
 
 @Injectable({ providedIn: 'root' })
 export class AxisService {
   resourceAxis$ = this.scalesService.scales$.pipe(
     map(scales =>
       this.createAxis(
-        scales.scaleBand,
+        new ResourceAxisTickRenderer(scales.scaleBand),
         scales.state.axisOrientations.resourceOrientation,
         scales.state.view
       )
@@ -24,7 +27,7 @@ export class AxisService {
   timeAxis$ = this.scalesService.scales$.pipe(
     map(scales =>
       this.createAxis(
-        scales.scaleTime,
+        new TimeAxisTickRenderer(scales.scaleTime),
         scales.state.axisOrientations.timeOrientation,
         scales.state.view
       )
@@ -37,61 +40,29 @@ export class AxisService {
   ) {}
 
   private createAxis(
-    scale: BandScale | TimeScale,
+    tickRenderer: TickRenderer,
     orientation: Orientation,
     timelineView: TimelineView
   ): Axis {
     return {
-      ticks: this.getTicks(scale, orientation, timelineView),
-      axisLine: this.getAxisLine(scale, orientation, timelineView)
+      ticks: this.getTicks(tickRenderer, orientation, timelineView),
+      axisLine: this.getAxisLine(tickRenderer, orientation, timelineView)
     };
   }
 
   private getTicks(
-    scale: BandScale | TimeScale,
+    tickRenderer: TickRenderer,
     orientation: Orientation,
     timelineView: TimelineView
   ): Tick[] {
-    return this.getScaleTicks(scale).map(value => ({
-      label: this.getLabel(scale, value),
+    return tickRenderer.getTickValues().map(value => ({
+      label: tickRenderer.getLabel(value),
       transform: this.optionsService.getTranslation(
-        this.getTransform(scale, value),
+        tickRenderer.getTransform(value),
         orientation,
         timelineView
       )
     }));
-  }
-
-  private getScaleTicks(scale: TimeScale | BandScale): any[] {
-    if (this.isScaleTime(scale)) {
-      return scale.ticks();
-    }
-
-    return (scale as BandScale).domain();
-  }
-
-  private getLabel(scale: TimeScale | BandScale, tick: any) {
-    if (this.isScaleTime(scale)) {
-      return scale.tickFormat()(tick);
-    }
-
-    return tick;
-  }
-
-  private getTransform(scale: TimeScale | BandScale, tick: any) {
-    if (this.isScaleTime(scale)) {
-      return scale(tick);
-    }
-
-    return this.getBandMidPoint(scale as BandScale, tick);
-  }
-
-  private isScaleTime(scale: TimeScale | BandScale): scale is TimeScale {
-    return scale.domain()[0] instanceof Date;
-  }
-
-  private getBandMidPoint(scale: BandScale, tick: string) {
-    return scale(tick) + scale.bandwidth() / 2;
   }
 
   private getAxisLine(

--- a/projects/ngx-d3timeline/src/lib/axis/axis.service.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/axis.service.ts
@@ -18,6 +18,7 @@ export class AxisService {
     map(scales =>
       this.createAxis(
         new ResourceAxisTickRenderer(scales.scaleBand),
+        scales.scaleBand,
         scales.state.axisOrientations.resourceOrientation,
         scales.state.view
       )
@@ -28,6 +29,7 @@ export class AxisService {
     map(scales =>
       this.createAxis(
         new TimeAxisTickRenderer(scales.scaleTime),
+        scales.scaleTime,
         scales.state.axisOrientations.timeOrientation,
         scales.state.view
       )
@@ -41,12 +43,13 @@ export class AxisService {
 
   private createAxis(
     tickRenderer: TickRenderer,
+    scale: BandScale | TimeScale,
     orientation: Orientation,
     timelineView: TimelineView
   ): Axis {
     return {
       ticks: this.getTicks(tickRenderer, orientation, timelineView),
-      axisLine: this.getAxisLine(tickRenderer, orientation, timelineView)
+      axisLine: this.getAxisLine(scale, orientation, timelineView)
     };
   }
 

--- a/projects/ngx-d3timeline/src/lib/axis/resources-axis/resource-axis-tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/resources-axis/resource-axis-tick-renderer.ts
@@ -4,19 +4,19 @@ import { TickRenderer } from '../tick-renderer';
 export class ResourceAxisTickRenderer implements TickRenderer {
   constructor(private scale: BandScale) {}
 
-  getTickValues(): any[] {
+  getTickValues(): string[] {
     return this.scale.domain();
   }
 
-  getLabel(tick: any) {
+  getLabel(tick: any): string {
     return tick;
   }
 
-  getTransform(tick: any) {
+  getTransform(tick: any): number {
     return this.getBandMidPoint(tick);
   }
 
-  private getBandMidPoint(tick: string) {
+  private getBandMidPoint(tick: string): number {
     return this.scale(tick) + this.scale.bandwidth() / 2;
   }
 }

--- a/projects/ngx-d3timeline/src/lib/axis/resources-axis/resource-axis-tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/resources-axis/resource-axis-tick-renderer.ts
@@ -1,22 +1,20 @@
 import { BandScale } from '../../scale-types';
 import { TickRenderer } from '../tick-renderer';
 
-export class ResourceAxisTickRenderer implements TickRenderer {
-  constructor(private scale: BandScale) {}
-
-  getTickValues(): string[] {
-    return this.scale.domain();
+export class ResourceAxisTickRenderer implements TickRenderer<BandScale> {
+  getTickValues(scale: BandScale): string[] {
+    return scale.domain();
   }
 
-  getLabel(tick: any): string {
+  getLabel(_: BandScale, tick: any): string {
     return tick;
   }
 
-  getTransform(tick: any): number {
-    return this.getBandMidPoint(tick);
+  getTransform(scale: BandScale, tick: any): number {
+    return this.getBandMidPoint(scale, tick);
   }
 
-  private getBandMidPoint(tick: string): number {
-    return this.scale(tick) + this.scale.bandwidth() / 2;
+  private getBandMidPoint(scale: BandScale, tick: string): number {
+    return scale(tick) + scale.bandwidth() / 2;
   }
 }

--- a/projects/ngx-d3timeline/src/lib/axis/resources-axis/resource-axis-tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/resources-axis/resource-axis-tick-renderer.ts
@@ -1,0 +1,22 @@
+import { BandScale } from '../../scale-types';
+import { TickRenderer } from '../tick-renderer';
+
+export class ResourceAxisTickRenderer implements TickRenderer {
+  constructor(private scale: BandScale) {}
+
+  getTickValues(): any[] {
+    return this.scale.domain();
+  }
+
+  getLabel(tick: any) {
+    return tick;
+  }
+
+  getTransform(tick: any) {
+    return this.getBandMidPoint(tick);
+  }
+
+  private getBandMidPoint(tick: string) {
+    return this.scale(tick) + this.scale.bandwidth() / 2;
+  }
+}

--- a/projects/ngx-d3timeline/src/lib/axis/tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/tick-renderer.ts
@@ -1,0 +1,5 @@
+export interface TickRenderer {
+  getTickValues(): any[];
+  getLabel(tick: any);
+  getTransform(tick: any);
+}

--- a/projects/ngx-d3timeline/src/lib/axis/tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/tick-renderer.ts
@@ -1,5 +1,7 @@
-export interface TickRenderer {
-  getTickValues(): any[];
-  getLabel(tick: any): string;
-  getTransform(tick: any): number;
+import { Scale } from '../scale-types';
+
+export interface TickRenderer<TScale extends Scale> {
+  getTickValues(scale: TScale): any[];
+  getLabel(scale: TScale, tick: any): string;
+  getTransform(scale: TScale, tick: any): number;
 }

--- a/projects/ngx-d3timeline/src/lib/axis/tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/tick-renderer.ts
@@ -1,5 +1,5 @@
 export interface TickRenderer {
   getTickValues(): any[];
-  getLabel(tick: any);
-  getTransform(tick: any);
+  getLabel(tick: any): string;
+  getTransform(tick: any): number;
 }

--- a/projects/ngx-d3timeline/src/lib/axis/time-axis/time-axis-tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/time-axis/time-axis-tick-renderer.ts
@@ -1,18 +1,16 @@
 import { TimeScale } from '../../scale-types';
 import { TickRenderer } from '../tick-renderer';
 
-export class TimeAxisTickRenderer implements TickRenderer {
-  constructor(private scale: TimeScale) {}
-
-  getTickValues(): Date[] {
-    return this.scale.ticks();
+export class TimeAxisTickRenderer implements TickRenderer<TimeScale> {
+  getTickValues(scale: TimeScale): Date[] {
+    return scale.ticks();
   }
 
-  getLabel(tick: any): string {
-    return this.scale.tickFormat()(tick);
+  getLabel(scale: TimeScale, tick: any): string {
+    return scale.tickFormat()(tick);
   }
 
-  getTransform(tick: any): number {
-    return this.scale(tick);
+  getTransform(scale: TimeScale, tick: any): number {
+    return scale(tick);
   }
 }

--- a/projects/ngx-d3timeline/src/lib/axis/time-axis/time-axis-tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/time-axis/time-axis-tick-renderer.ts
@@ -4,15 +4,15 @@ import { TickRenderer } from '../tick-renderer';
 export class TimeAxisTickRenderer implements TickRenderer {
   constructor(private scale: TimeScale) {}
 
-  getTickValues(): any[] {
+  getTickValues(): Date[] {
     return this.scale.ticks();
   }
 
-  getLabel(tick: any) {
+  getLabel(tick: any): string {
     return this.scale.tickFormat()(tick);
   }
 
-  getTransform(tick: any) {
+  getTransform(tick: any): number {
     return this.scale(tick);
   }
 }

--- a/projects/ngx-d3timeline/src/lib/axis/time-axis/time-axis-tick-renderer.ts
+++ b/projects/ngx-d3timeline/src/lib/axis/time-axis/time-axis-tick-renderer.ts
@@ -1,0 +1,18 @@
+import { TimeScale } from '../../scale-types';
+import { TickRenderer } from '../tick-renderer';
+
+export class TimeAxisTickRenderer implements TickRenderer {
+  constructor(private scale: TimeScale) {}
+
+  getTickValues(): any[] {
+    return this.scale.ticks();
+  }
+
+  getLabel(tick: any) {
+    return this.scale.tickFormat()(tick);
+  }
+
+  getTransform(tick: any) {
+    return this.scale(tick);
+  }
+}

--- a/projects/ngx-d3timeline/src/lib/scale-types.ts
+++ b/projects/ngx-d3timeline/src/lib/scale-types.ts
@@ -2,3 +2,4 @@ import { ScaleBand, ScaleTime } from 'd3-scale';
 
 export type BandScale = ScaleBand<string>;
 export type TimeScale = ScaleTime<number, number>;
+export type Scale = BandScale | TimeScale;


### PR DESCRIPTION
Used generics as opposed to union types, feedback welcome on whether this is the way to go or not.